### PR TITLE
Add galaxy push workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+---
+name: Release to galaxy
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: gofrolist/molecule-action@v2
+  release:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: galaxy
+        uses: robertdebock/galaxy-action@1.1.0
+        with:
+          galaxy_api_key: ${{ secrets.galaxy_api_key }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,10 @@
 ---
 name: Molecule Test
 
-on: push
+on:
+  push:
+    branches:
+      - 'main'
 
 jobs:
   molecule:


### PR DESCRIPTION
This PR add an action to push a tagged commit to ansible galaxy. You can add a ``galaxy_api_key`` secret in your repo to use it. 