### PR TITLE
Make ansible-role-gnome-extensions work on debian 12 and debian 13 based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ The following playbook:
     - name: "Include ansible-role-gnome-extensions"
       include_role:
         name: "ansible-role-gnome-extensions"
+      vars:
+        download_only: yes
+
+    - name: "Include ansible-role-gnome-extensions"
+      debug: "logoff and logon or restart gnome-shell to reload extensions"
+
+    - name: "Include ansible-role-gnome-extensions"
+      include_role:
+        name: "ansible-role-gnome-extensions"
+      vars:
+        download_only: no
 ```
 
 ## Testing

--- a/tasks/extensions/install-extension.yml
+++ b/tasks/extensions/install-extension.yml
@@ -1,8 +1,7 @@
 ---
 # Tasks file for ansible-role-gnome-extensions: Install Extension
 
-# @todo Find out where exactly gnome-extensions is available and use it here if
-#   possible (i.e. gnome-extensions enable ...).
 - name: Install extension with gnome-shell-extension-tool.
-  ansible.builtin.command: "gnome-shell-extension-tool enable {{ gnome_extension_uuid }}" # noqa no-changed-when
-  become: "{{ gnome_user }}"
+  ansible.builtin.command: "gnome-extensions enable {{ gnome_extension_uuid }}" # noqa no-changed-when
+  become: true
+  become_user: "{{ gnome_user }}"

--- a/tasks/extensions/manage-extensions.yml
+++ b/tasks/extensions/manage-extensions.yml
@@ -5,10 +5,8 @@
 # since a previous iteration could have changed what's present and what's
 # installed.
 #
-# @todo Find out where exactly gnome-extensions is available and use it here if
-#   possible (i.e. gnome-extensions list).
 - name: Find all Gnome extensions.
-  ansible.builtin.command: "find {{ gnome_extensions_dir }} -mindepth 1 -maxdepth 1 -type d -printf \"%P\n\""
+  ansible.builtin.command: "gnome-extensions list"
   become_user: "{{ gnome_user }}"
   register: register__gnome_extensions
   changed_when: false
@@ -27,36 +25,36 @@
     gnome_extension_name: "{{ register__gnome_extension_data.json.name }}"
     gnome_extension_uuid: "{{ register__gnome_extension_data.json.uuid }}"
 
-- name: Download extension "\"{{ gnome_extension_name }}\"".
+- name: Download extension "{{ gnome_extension_name }}".
   ansible.builtin.include_tasks: "extensions/download-extension.yml"
   when:
     # Translated: the directory is NOT present, and one or both of 'present'
     # and 'installed' has been set for this extension.
     - "gnome_extension_uuid not in register__gnome_extensions.stdout"
-    - "gnome_extension.state == 'present' or gnome_extension.installed == 'true'"
+    - "gnome_extension.state == 'present' or gnome_extension.state == 'true'"
 
-- name: Install extension "\"{{ gnome_extension_name }}\"".
+- name: Install extension "{{ gnome_extension_name }}".
   ansible.builtin.include_tasks: "extensions/install-extension.yml"
   when:
     # Translated: when the item is not in the installed list (the directory
     # will always be present by now).
     #- "'State: DISABLED' in register__gnome_extension.info.stdout"
-    - "gnome_extension.installed == 'true'"
+    - "gnome_extension.state == 'present'"
   tags:
     - molecule-notest
 
-- name: Uninstall extension "\"{{ gnome_extension_name }}\"".
+- name: Uninstall extension "{{ gnome_extension_name }}".
   ansible.builtin.include_tasks: "extensions/uninstall-extension.yml"
   when:
     # Translated: when the items is present and installed, and set to 'absent'
     # or 'uninstalled'.
     - "gnome_extension_uuid in register__gnome_extensions.stdout"
       #- "'State: ENABLED' in register__gnome_extension.info.stdout"
-    - "gnome_extension.state == 'absent' or gnome_extension.installed == 'false'"
+    - "gnome_extension.state == 'absent'"
   tags:
     - molecule-notest
 
-- name: Uninstall extension "\"{{ gnome_extension_name }}\"".
+- name: Uninstall extension "{{ gnome_extension_name }}".
   ansible.builtin.include_tasks: "extensions/remove-extension.yml"
   when:
     - "gnome_extension_uuid in register__gnome_extensions.stdout"

--- a/tasks/extensions/manage-extensions.yml
+++ b/tasks/extensions/manage-extensions.yml
@@ -40,7 +40,7 @@
   when:
     # Translated: when the item is not in the installed list (the directory
     # will always be present by now).
-    - "'State: DISABLED' in register__gnome_extension.info.stdout"
+    #- "'State: DISABLED' in register__gnome_extension.info.stdout"
     - "gnome_extension.installed == 'true'"
   tags:
     - molecule-notest
@@ -51,7 +51,7 @@
     # Translated: when the items is present and installed, and set to 'absent'
     # or 'uninstalled'.
     - "gnome_extension_uuid in register__gnome_extensions.stdout"
-    - "'State: ENABLED' in register__gnome_extension.info.stdout"
+      #- "'State: ENABLED' in register__gnome_extension.info.stdout"
     - "gnome_extension.state == 'absent' or gnome_extension.installed == 'false'"
   tags:
     - molecule-notest

--- a/tasks/extensions/manage-extensions.yml
+++ b/tasks/extensions/manage-extensions.yml
@@ -36,9 +36,7 @@
 - name: Install extension "{{ gnome_extension_name }}".
   ansible.builtin.include_tasks: "extensions/install-extension.yml"
   when:
-    # Translated: when the item is not in the installed list (the directory
-    # will always be present by now).
-    #- "'State: DISABLED' in register__gnome_extension.info.stdout"
+    - "not download_only"
     - "gnome_extension.state == 'present'"
   tags:
     - molecule-notest

--- a/tasks/extensions/uninstall-extension.yml
+++ b/tasks/extensions/uninstall-extension.yml
@@ -1,8 +1,6 @@
 ---
 # Tasks file for ansible-role-gnome-extensions: Uninstall Extension
 
-# @todo Find out where exactly gnome-extensions is available and use it here if
-#   possible (i.e. gnome-extensions disable ...).
-- name: Uninstall extension with gnome-shell-extension-tool.
-  ansible.builtin.command: "gnome-shell-extension-tool disable {{ gnome_extension_uuid }}" # noqa no-changed-when
+- name: Uninstall extension with gnome-extensions
+  ansible.builtin.command: "gnome-extensions disable {{ gnome_extension_uuid }}" # noqa no-changed-when
   become: "{{ gnome_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,11 @@
   ansible.builtin.package: "{{ gnome_extensions }}"
 
 - name: Get the Gnome version.
-  ansible.builtin.command: "gnome-shell --version"
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      gnome-shell --version | sed 's/^[^0-9.]*//' | sed 's/[^0-9]*$//'
+    executable: /bin/bash
   register: register__gnome_version
   changed_when: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Set some initial facts.
   ansible.builtin.set_fact:
     gnome_extensions_dir: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/"
-    gnome_version: "{{ register__gnome_version.stdout|regex_search('\\d+\\.\\d+\\.\\d+') }}"
+    gnome_version: "{{ register__gnome_version.stdout|regex_search('\\d+\\.\\d+\\.?\\d?') }}"
 
 - name: Add, remove, install, and uninstall extensions.
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
 # tasks file for ansible-role-gnome-extensions
 
-- name: Install required packages.
-  ansible.builtin.package: "{{ gnome_extensions }}"
-
 - name: Get the Gnome version.
   ansible.builtin.shell:
     cmd: |
@@ -16,7 +13,7 @@
 - name: Set some initial facts.
   ansible.builtin.set_fact:
     gnome_extensions_dir: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/"
-    gnome_version: "{{ register__gnome_version.stdout }}"
+    gnome_version: "{{ register__gnome_version.stdout|regex_search('\\d+\\.\\d+\\.\\d+') }}"
 
 - name: Add, remove, install, and uninstall extensions.
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Set some initial facts.
   ansible.builtin.set_fact:
     gnome_extensions_dir: "/home/{{ gnome_user }}/.local/share/gnome-shell/extensions/"
-    gnome_version: "{{ register__gnome_version.stdout|regex_search('\\d+\\.\\d+\\.\\d+') }}"
+    gnome_version: "{{ register__gnome_version.stdout }}"
 
 - name: Add, remove, install, and uninstall extensions.
   block:


### PR DESCRIPTION
Unfortunately, I did not find a better way to reload the list of available extensions in `gnome-extensions list` so people have to log off and on again for this to work.

I don't know how the web extension does this without logoff.

This works now when executed twice - once with download_only and once without